### PR TITLE
Añadir función cálculo SIR 

### DIFF
--- a/src/main/java/earlywarn/ejemplos/Prueba.java
+++ b/src/main/java/earlywarn/ejemplos/Prueba.java
@@ -127,15 +127,6 @@ public class Prueba {
 		return (consultas.getSIRInicialPorVuelo(idVuelo)).getListaSIR();
 	}
 
-	/*@Procedure(mode = Mode.WRITE)
-	@Description("Añade el riesgo importado del vuelo con identificador 'idVuelo' en la base de datos.")
-	public void añadirRiesgoVuelo(@Name("idVuelo") Number idVuelo,
-								  @Name("resultadoRiesgo") Map<String,Double> resultadoRiesgo){
-		Consultas consultas = new Consultas(db);
-		consultas.añadirRiesgoVuelo((long) idVuelo, resultadoRiesgo);
-	}*/
-
-
 	@SuppressWarnings("FloatingPointEquality")
 	@Procedure(mode = Mode.WRITE)
 	@Description("Calcula los valores del SIR (Susceptibles, Infectados y Recuperados) al final del vuelo con el identificador <<idVuelo>>, " +

--- a/src/main/java/earlywarn/etl/Añadir.java
+++ b/src/main/java/earlywarn/etl/Añadir.java
@@ -22,7 +22,6 @@ public class Añadir {
 	@Context
 	public GraphDatabaseService db;
 
-
 	/**
 	 * Requerido por Neo4J
 	 * @deprecated Este constructor no debe utilizarse. Usar {@link Añadir#Añadir(GraphDatabaseService)} en su lugar.

--- a/src/main/java/earlywarn/etl/Modificar.java
+++ b/src/main/java/earlywarn/etl/Modificar.java
@@ -1,13 +1,11 @@
 package earlywarn.etl;
 
-import earlywarn.definiciones.Globales;
 import earlywarn.definiciones.Propiedad;
 import earlywarn.main.Propiedades;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Mode;
-import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
 /**

--- a/src/main/java/earlywarn/main/CalculoSIR.java
+++ b/src/main/java/earlywarn/main/CalculoSIR.java
@@ -1,10 +1,12 @@
 package earlywarn.main;
 
-import earlywarn.definiciones.SIRVuelo;
+import earlywarn.main.modelo.SIRVuelo;
 
 public class CalculoSIR {
 
-    public static SIRVuelo calcularRiesgoVuelo(double sInitial, double iInitial, double rInitial, double durationInSeconds, double seatsCapacity, double occupancyPercentage, double alpha, double beta){
+    public static SIRVuelo calcularRiesgoVuelo(double sInitial, double iInitial, double rInitial,
+                                               double durationInSeconds, double seatsCapacity,
+                                               double occupancyPercentage, double alpha, double beta) {
         SIRVuelo ret;
         double sFinal = sInitial;
         double iFinal = iInitial;

--- a/src/main/java/earlywarn/main/modelo/SIR.java
+++ b/src/main/java/earlywarn/main/modelo/SIR.java
@@ -1,4 +1,4 @@
-package earlywarn.definiciones;
+package earlywarn.main.modelo;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/earlywarn/main/modelo/SIRAeropuerto.java
+++ b/src/main/java/earlywarn/main/modelo/SIRAeropuerto.java
@@ -1,4 +1,4 @@
-package earlywarn.definiciones;
+package earlywarn.main.modelo;
 
 import java.util.TreeMap;
 

--- a/src/main/java/earlywarn/main/modelo/SIRVuelo.java
+++ b/src/main/java/earlywarn/main/modelo/SIRVuelo.java
@@ -1,4 +1,4 @@
-package earlywarn.definiciones;
+package earlywarn.main.modelo;
 
 import java.util.TreeMap;
 


### PR DESCRIPTION
Se ha añadido la funcionalidad del cálculo SIR, que incluye las siguientes funciones:
- Función para calcular el SIR de un vuelo en concreto. 
- Función para calcular el riesgo importado en un aeropuerto en un día en concreto.

NOTA: Ninguna de las dos funciones guarga el riesgo por defecto, para hacerlo hay que especificarlo en los parámetros al llamar a la función.